### PR TITLE
Issue #36: Mermaidレンダリング安定化 + 例題YAML導線整理 + 用語集導線調整

### DIFF
--- a/docs/examples/common-example/index.md
+++ b/docs/examples/common-example/index.md
@@ -13,7 +13,7 @@ description: "全章で参照する共通例題（Order/Payment/Inventory/Shipme
 - 例題 Context Pack（YAML）:
   - raw（推奨）: [raw](https://raw.githubusercontent.com/itdojp/categorical-software-design-book/main/docs/examples/common-example/context-pack-v1.yaml)
   - GitHub: [GitHub](https://github.com/itdojp/categorical-software-design-book/blob/main/docs/examples/common-example/context-pack-v1.yaml)
-  - GitHub Pages: [context-pack-v1.yaml](context-pack-v1.yaml)
+  - サイト内で読む: [YAML（全文）](#yaml-full)
 
 ## 最小lint（ローカル）
 
@@ -21,7 +21,7 @@ description: "全章で参照する共通例題（Order/Payment/Inventory/Shipme
 python3 scripts/validate-context-pack.py docs/examples/common-example/context-pack-v1.yaml
 ```
 
-## YAML（全文）
+## YAML（全文） {#yaml-full}
 
 ```yaml
 {% include_relative context-pack-v1.yaml %}

--- a/index.md
+++ b/index.md
@@ -85,7 +85,7 @@ graph TD
 
 ## 用語集
 
-- 用語・訳語のSSOT: [GLOSSARY.md](GLOSSARY.md)（GitHub: [GLOSSARY.md](https://github.com/itdojp/categorical-software-design-book/blob/main/GLOSSARY.md)）
+- 用語・訳語のSSOT: [/glossary/](GLOSSARY.md)（GitHub: [GLOSSARY.md](https://github.com/itdojp/categorical-software-design-book/blob/main/GLOSSARY.md)）
 - 用語/記法/図式の統一ルール:
   - [docs/style/terminology.md](docs/style/terminology.md)
   - [docs/style/notation.md](docs/style/notation.md)


### PR DESCRIPTION
Issue #36 の残課題（Mermaid図式のレンダリング安定化／表の整形確認／共通例題YAMLリンクの整理／トップの用語集導線）を対応します。

## 変更点
- Mermaidレンダリングを堅牢化（CDNフォールバック、非同期失敗の捕捉、Mermaidらしいコードブロックの検出）
- 共通例題ハブから GitHub Pages の `.yaml` 直リンクを廃止し、raw/GitHub/ページ内YAML全文（アンカー）に統一
- トップの「用語集（SSOT）」導線を `/glossary/` 優先表示に調整

## 検証
- `python3 scripts/validate-context-pack.py docs/examples/common-example/context-pack-v1.yaml`
- book-formatter（check-links/unicode/layout-risk/markdown-structure/textlint）

Closes #36
