### PR TITLE
Issue #38: Context Pack最小例/スケルトンをSchema-validに統一

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install pyyaml
           python scripts/validate-context-pack.py docs/examples/common-example/context-pack-v1.yaml
+          python scripts/validate-context-pack.py docs/examples/minimal-example/context-pack-v1.yaml
 
       - name: Upload reports
         if: always()

--- a/appendices/templates/index.md
+++ b/appendices/templates/index.md
@@ -9,6 +9,8 @@ appendix: templates
 
 ## Context Pack（最小スケルトン）
 
+このスケルトンは `scripts/validate-context-pack.py` を通る（Schema-valid）形です。
+
 ```yaml
 version: 1
 name: <project-or-example-name>
@@ -25,9 +27,19 @@ morphisms: []
 diagrams: []
 
 constraints: {}
-acceptance_tests: []
-coding_conventions: {}
-forbidden_changes: []
+
+acceptance_tests:
+  - id: AT1-happy-path
+    scenario: "<scenario>"
+    expected: ["<expected>"]
+
+coding_conventions:
+  language: language-agnostic
+  directory: []
+  dependencies: {}
+
+forbidden_changes:
+  - "<forbidden change>"
 ```
 
 ## Objects テンプレ（型/状態/不変条件/権限/エラー）

--- a/chapters/chapter01/index.md
+++ b/chapters/chapter01/index.md
@@ -100,6 +100,21 @@ diagrams:
     statement: "重要操作は必ず監査証跡を残す"
     verification:
       - "操作が成功した場合、対応するAuditEventが存在する"
+
+constraints: {}
+
+acceptance_tests:
+  - id: AT1-happy-path
+    scenario: Draft の Order に PlaceOrder を適用する
+    expected:
+      - "Order.state == Placed"
+      - "AuditEvent(\"PlaceOrder\") が記録される"
+
+coding_conventions:
+  language: language-agnostic
+  directory: []
+  dependencies: {}
+
 forbidden_changes:
   - "Diagrams（不変条件）を満たさない変更"
 ```

--- a/docs/examples/minimal-example/context-pack-v1.yaml
+++ b/docs/examples/minimal-example/context-pack-v1.yaml
@@ -1,0 +1,43 @@
+version: 1
+name: minimal-example
+
+problem_statement:
+  goals: ["最小の例として成立させる"]
+  non_goals: ["仕様追加をしない"]
+
+domain_glossary:
+  terms:
+    - term: Order
+      ja: 注文
+
+objects:
+  - id: Order
+    kind: entity
+
+morphisms:
+  - id: PlaceOrder
+    input: { orderId: "OrderId" }
+    output: { orderId: "OrderId" }
+    pre: ["Order.state == Draft"]
+    post: ["Order.state == Placed"]
+    failures: ["InvalidState"]
+
+diagrams:
+  - id: D1-order-state
+    statement: "PlaceOrder は Draft のみに適用できる"
+    verification: ["Draft 以外では InvalidState になる"]
+
+constraints: {}
+
+acceptance_tests:
+  - id: AT1-happy-path
+    scenario: Draft の Order に PlaceOrder を適用する
+    expected: ["Order.state == Placed"]
+
+coding_conventions:
+  language: language-agnostic
+  directory: []
+  dependencies: {}
+
+forbidden_changes:
+  - "Diagrams を満たさない変更"

--- a/docs/spec/context-pack-v1.md
+++ b/docs/spec/context-pack-v1.md
@@ -93,6 +93,12 @@ AIが勝手に変更してはいけない事項を明示します。
 
 以下は「必須キー＋最小要素」だけで成立する例です（章末演習の叩き台）。
 
+“コピペして使う最小例” の SSOT はファイルとして管理します。
+
+- YAML（raw）: [raw](https://raw.githubusercontent.com/itdojp/categorical-software-design-book/main/docs/examples/minimal-example/context-pack-v1.yaml)
+- YAML（GitHub）: [GitHub](https://github.com/itdojp/categorical-software-design-book/blob/main/docs/examples/minimal-example/context-pack-v1.yaml)
+- YAML（リポジトリ内）: [docs/examples/minimal-example/context-pack-v1.yaml](../examples/minimal-example/context-pack-v1.yaml)
+
 ```yaml
 version: 1
 name: minimal-example


### PR DESCRIPTION
## 概要

- 目的: Context Pack v1 の「最小例/スケルトン」のコピペ運用で破綻しないよう、Schema-valid（`scripts/validate-context-pack.py` で validate 成功）に統一し、最小例への導線を整備する
- 対象Issue: #38 #43
- 関連Issue: #42

## 変更内容

### Schema-valid 統一（Issue #38）

- `appendices/templates/index.md`: 最小スケルトンを Schema-valid 化（`coding_conventions.language`/`directory`/`dependencies` を追加）
- `chapters/chapter01/index.md`: 「最小Context Pack（例）」を Schema-valid 化（`constraints`/`acceptance_tests`/`coding_conventions` を追加）
- `docs/examples/minimal-example/context-pack-v1.yaml`: Minimal valid example の SSOT ファイルを追加
- `docs/spec/context-pack-v1.md`: SSOT ファイル（raw/GitHub）への導線を追記
- `.github/workflows/ci.yml`: minimal-example も `validate-context-pack.py` で検証

### 導線整備（Issue #43）

- `docs/examples/minimal-example/index.md`: minimal-example のハブページ追加（YAML全文をページ内表示）
- `docs/spec/context-pack-v1.md`: 例題導線をハブページ（`index.md`）へ統一し、`.yaml` のサイト内直リンクを廃止
- `index.md`: Quick Start を minimal-example → common-example の順に整理

## ローカル検証

- `python3 scripts/validate-context-pack.py docs/examples/minimal-example/context-pack-v1.yaml`
- `python3 scripts/validate-context-pack.py docs/examples/common-example/context-pack-v1.yaml`
- book-formatter: `check-links` / `check-unicode` / `check-layout-risk` / `check-markdown-structure` / `check-textlint`

## チェックリスト

- [x] 主要リンクが壊れていない
- [x] Context Pack v1 が Schema-valid（validate成功）
- [ ] CI（Book QA）が通る

Fixes #38
Fixes #43
Refs #42
