### PR TITLE
Issue #45: common-exampleのTBD除去 + placeholder混入をCIで検出

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
           python scripts/validate-context-pack.py docs/examples/common-example/context-pack-v1.yaml
           python scripts/validate-context-pack.py docs/examples/minimal-example/context-pack-v1.yaml
           python scripts/check-context-pack-minimal-example-sync.py
+          python scripts/check-placeholders.py
 
       - name: Upload reports
         if: always()

--- a/docs/examples/common-example/context-pack-v1.yaml
+++ b/docs/examples/common-example/context-pack-v1.yaml
@@ -136,7 +136,9 @@ constraints:
     - 監査イベントは削除不可（論理削除も禁止、訂正は追記で行う）
     - actor（操作者）を必須にする（匿名操作は不可）
   operations:
-    - 監査イベントの検索・エクスポート経路を用意する（後続タスクで具体化）
+    - 監査イベントの検索・エクスポート経路を用意する
+    - 検索は occurredAt の期間、actor/action/target でフィルタできる
+    - エクスポートは CSV または JSON を提供し、権限によりアクセス制御される
 
 acceptance_tests:
   - id: AT1-happy-path
@@ -148,6 +150,11 @@ acceptance_tests:
     scenario: Draft の Order に対して ShipOrder を呼ぶ
     expected:
       - InvalidState
+  - id: AT3-audit-search-export
+    scenario: 監査イベントを actor/action/target/期間 で検索し、CSV または JSON でエクスポートする
+    expected:
+      - 検索結果に CreateOrder/PlaceOrder/AuthorizePayment/ShipOrder の監査イベントが含まれる
+      - 権限のない actor は検索・エクスポートできない
 
 coding_conventions:
   language: language-agnostic

--- a/scripts/check-placeholders.py
+++ b/scripts/check-placeholders.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+TARGETS = [
+    ROOT / "index.md",
+    ROOT / "GLOSSARY.md",
+]
+
+GLOBS = [
+    ROOT / "chapters/**/*.md",
+    ROOT / "appendices/**/*.md",
+    ROOT / "docs/**/*.md",
+    ROOT / "docs/examples/**/*.*",
+]
+
+ALLOWED_EXAMPLE_EXTS = {".yml", ".yaml", ".json"}
+
+ALLOWLIST_FILE = ROOT / ".book-formatter/placeholder-allowlist.txt"
+
+PATTERN = re.compile(
+    r"\b(?:TBD|TODO|FIXME|WIP)\b|執筆中|準備中|未作成|後続タスク",
+    flags=re.IGNORECASE,
+)
+
+
+def load_allowlist() -> set[Path]:
+    if not ALLOWLIST_FILE.exists():
+        return set()
+
+    allow: set[Path] = set()
+    for raw in ALLOWLIST_FILE.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if line == "" or line.startswith("#"):
+            continue
+        allow.add((ROOT / line).resolve())
+    return allow
+
+
+def iter_files() -> Iterable[Path]:
+    for p in TARGETS:
+        if p.exists():
+            yield p
+
+    for g in GLOBS:
+        # Path.glob accepts "**" patterns relative to the base path,
+        # but we keep absolute roots for clarity.
+        for p in ROOT.glob(str(g.relative_to(ROOT))):
+            if not p.is_file():
+                continue
+            if p.suffix.lower() in (".md",):
+                yield p
+                continue
+            if p.suffix.lower() in ALLOWED_EXAMPLE_EXTS:
+                yield p
+
+
+def main() -> int:
+    allowlist = load_allowlist()
+
+    hits: list[tuple[Path, int, str]] = []
+    for file_path in sorted({p.resolve() for p in iter_files()}):
+        if file_path in allowlist:
+            continue
+
+        try:
+            text = file_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            # Treat non-UTF-8 files as out of scope for placeholder checks.
+            continue
+
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if PATTERN.search(line):
+                hits.append((file_path, lineno, line))
+
+    if not hits:
+        print("✅ No placeholders found.")
+        return 0
+
+    print("❌ Placeholders found:", file=sys.stderr)
+    for file_path, lineno, line in hits:
+        rel = file_path.relative_to(ROOT)
+        print(f"- {rel}:{lineno}: {line}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## 概要

- 目的: 本文/例題/仕様へ “TBD/後続タスク” 等の未確定表現が混入するのを防ぎ、公開内容を確定情報に寄せる
- 対象Issue: #45

## 変更内容

- `docs/examples/common-example/context-pack-v1.yaml`
  - `constraints.operations` の「（後続タスクで具体化）」を削除
  - 監査検索/エクスポートの最小契約（フィルタ条件/フォーマット/権限制御）を追記
  - 監査検索/エクスポートの受入条件を1件追加（AT3）
- `scripts/check-placeholders.py`
  - placeholder（`TBD/TODO/FIXME/WIP/執筆中/準備中/未作成/後続タスク`）混入を検出し、`file:line` を出力して失敗
- `.github/workflows/ci.yml`
  - Pythonステップで `python scripts/check-placeholders.py` を実行

## ローカル検証

- `python3 scripts/validate-context-pack.py docs/examples/common-example/context-pack-v1.yaml`
- `python3 scripts/validate-context-pack.py docs/examples/minimal-example/context-pack-v1.yaml`
- `python3 scripts/check-placeholders.py`

## チェックリスト

- [x] Context Pack v1 validate が成功
- [x] placeholder チェックが成功
- [ ] CI（Book QA）が通る

Fixes #45
