### PR TITLE
Issue #51: READMEにnpm run qa導線 + Schema-valid表記修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@ bundle exec jekyll serve --livereload --baseurl ""
 bundle exec jekyll build
 ```
 
-## 品質チェック（book-formatter）
+## 品質チェック（ローカルQA）
 
-CIでは `itdojp/book-formatter` のチェッカー（リンク/Unicode/構造/textlint等）を実行します。ローカルで同等のチェックを行う場合は、book-formatter を取得して実行してください（詳細は `.github/workflows/ci.yml` を参照）。
+CIでは `itdojp/book-formatter` のチェッカー（リンク/Unicode/構造/textlint等）と、Context Pack 検証スクリプトを実行します。ローカルでは `npm run qa` で主要チェックを一括実行できます（`book-formatter/` は自動取得/更新）。
+
+前提:
+- Node.js（CIは Node 20）
+- Python 3（CIは Python 3.12）
+- Git / Bash
+- （推奨）Python仮想環境（venv/conda）
+
+実行:
+
+```bash
+npm run qa
+```
+
+出力:
+- `qa-reports/*.json`
+
+詳細は `scripts/qa.sh` と `.github/workflows/ci.yml` を参照してください。

--- a/docs/examples/minimal-example/index.md
+++ b/docs/examples/minimal-example/index.md
@@ -1,6 +1,6 @@
 ---
 title: "最小例: minimal-example（Context Pack v1）"
-description: "Context Pack v1 の最小の有効例（Schema-valid）"
+description: "Context Pack v1 の最小の有効例（minimal lint）"
 ---
 
 # 最小例: minimal-example（Context Pack v1）


### PR DESCRIPTION
Fixes #51

## 変更内容
- README に `npm run qa`（CI相当の主要チェック一括実行）の導線を追加
- `docs/examples/minimal-example/index.md` の "Schema-valid" 表記を "minimal lint" に修正（`scripts/validate-context-pack.py` の実態に合わせる）

## 補足
- `scripts/qa.sh` 追加および付録Aの文言修正は PR #50 で main に反映済みです。本PRは Issue #51 の残件（README導線）と表記ゆれを追補します。
