### PR TITLE
Issue #55: 章テンプレリンク修正 + 依存導線追記 + CI検知追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           python scripts/validate-context-pack-schema.py docs/examples/minimal-example/context-pack-v1.yaml
           python scripts/check-context-pack-minimal-example-sync.py
           python scripts/check-placeholders.py
+          python scripts/check-invalid-markdown-links.py
 
       - name: Upload reports
         if: always()

--- a/docs/spec/context-pack-v1.md
+++ b/docs/spec/context-pack-v1.md
@@ -22,6 +22,12 @@ Context Pack は YAML/JSON のいずれでもよいが、レビュー容易性�
 
 検証コマンド:
 
+依存導入（初回のみ）:
+
+```bash
+python3 -m pip install -r scripts/requirements-qa.txt
+```
+
 minimal lint（必須項目/型/ID重複/参照整合の簡易検証）:
 
 ```bash

--- a/docs/style/chapter-template.md
+++ b/docs/style/chapter-template.md
@@ -59,7 +59,7 @@ chapter: chapterNN
 ## PRレビュー観点（章テンプレ遵守）
 
 - 見出し構造がテンプレに沿っている
-- 用語・記法がスタイルガイド（[用語ガイド]({{ '/docs/style/terminology/' | relative_url }}）、[記法ガイド]({{ '/docs/style/notation/' | relative_url }}）に沿っている
-- 共通例題（[共通例題（注文処理）]({{ '/docs/examples/common-example/' | relative_url }}））への参照が一貫している
+- 用語・記法がスタイルガイド（[用語ガイド]({{ '/docs/style/terminology/' | relative_url }})、[記法ガイド]({{ '/docs/style/notation/' | relative_url }})）に沿っている
+- 共通例題（[共通例題（注文処理）]({{ '/docs/examples/common-example/' | relative_url }})）への参照が一貫している
 - 可換性（不変条件）が「検証可能な形」で記述されている（テスト観点/受入条件に落ちている）
 - AI引き渡しが Context Pack v1 形式で再現できる（[Context Pack v1 仕様]({{ '/docs/spec/context-pack-v1/' | relative_url }})）

--- a/index.md
+++ b/index.md
@@ -46,6 +46,7 @@ description: "仕様・設計・検証を合成可能にする共通言語"
 2. 最小例（minimal-example）を読む: [docs/examples/minimal-example/](docs/examples/minimal-example/)（[raw](https://raw.githubusercontent.com/itdojp/categorical-software-design-book/main/docs/examples/minimal-example/context-pack-v1.yaml)）
 3. 次に共通例題（注文処理）を読む: [docs/examples/common-example/](docs/examples/common-example/)（[raw](https://raw.githubusercontent.com/itdojp/categorical-software-design-book/main/docs/examples/common-example/context-pack-v1.yaml)）
 4. Context Packの最小lintを実行する:
+   - （初回のみ）`python3 -m pip install -r scripts/requirements-qa.txt`
    - `python3 scripts/validate-context-pack.py docs/examples/minimal-example/context-pack-v1.yaml`
    - `python3 scripts/validate-context-pack.py docs/examples/common-example/context-pack-v1.yaml`
    （[scripts/validate-context-pack.py](https://github.com/itdojp/categorical-software-design-book/blob/main/scripts/validate-context-pack.py)）

--- a/scripts/check-invalid-markdown-links.py
+++ b/scripts/check-invalid-markdown-links.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+EXCLUDE_DIRS = {
+    ".git",
+    "_site",
+    "vendor",
+    "node_modules",
+    "book-formatter",
+    "qa-reports",
+}
+
+FENCE_RE = re.compile(r"^\s*```")
+INVALID_LINK_RE = re.compile(r"\]\([^)\n]*）")
+
+
+def iter_markdown_files() -> list[Path]:
+    files: list[Path] = []
+    for p in ROOT.rglob("*.md"):
+        if any(part in EXCLUDE_DIRS for part in p.parts):
+            continue
+        if p.is_file():
+            files.append(p)
+    return sorted(files)
+
+
+def main() -> int:
+    hits: list[tuple[Path, int, str]] = []
+
+    for file_path in iter_markdown_files():
+        try:
+            text = file_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+
+        in_fence = False
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if FENCE_RE.match(line):
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                continue
+
+            if INVALID_LINK_RE.search(line):
+                hits.append((file_path, lineno, line))
+
+    if not hits:
+        print("✅ No invalid markdown links found.")
+        return 0
+
+    print("❌ Invalid markdown links found (full-width '）' inside link URL parentheses):", file=sys.stderr)
+    for file_path, lineno, line in hits:
+        rel = file_path.relative_to(ROOT)
+        print(f"- {rel}:{lineno}: {line}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -88,5 +88,6 @@ python3 "$ROOT/scripts/validate-context-pack-schema.py" "$ROOT/docs/examples/com
 python3 "$ROOT/scripts/validate-context-pack-schema.py" "$ROOT/docs/examples/minimal-example/context-pack-v1.yaml"
 python3 "$ROOT/scripts/check-context-pack-minimal-example-sync.py"
 python3 "$ROOT/scripts/check-placeholders.py"
+python3 "$ROOT/scripts/check-invalid-markdown-links.py"
 
 echo "✅ QA complete. Reports: $REPORT_DIR"

--- a/scripts/validate-context-pack-schema.py
+++ b/scripts/validate-context-pack-schema.py
@@ -9,8 +9,19 @@ import sys
 from pathlib import Path
 from typing import Any, Iterable
 
-import yaml
-from jsonschema import Draft202012Validator
+try:
+    import yaml
+except ImportError:
+    print("❌ Missing dependency: pyyaml", file=sys.stderr)
+    print("   Install: python3 -m pip install -r scripts/requirements-qa.txt", file=sys.stderr)
+    raise SystemExit(2)
+
+try:
+    from jsonschema import Draft202012Validator
+except ImportError:
+    print("❌ Missing dependency: jsonschema", file=sys.stderr)
+    print("   Install: python3 -m pip install -r scripts/requirements-qa.txt", file=sys.stderr)
+    raise SystemExit(2)
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -101,4 +112,3 @@ def main(argv: list[str]) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main(sys.argv[1:]))
-

--- a/scripts/validate-context-pack.py
+++ b/scripts/validate-context-pack.py
@@ -10,7 +10,12 @@ import sys
 from dataclasses import dataclass
 from typing import Any
 
-import yaml
+try:
+    import yaml
+except ImportError:
+    print("❌ Missing dependency: pyyaml", file=sys.stderr)
+    print("   Install: python3 -m pip install -r scripts/requirements-qa.txt", file=sys.stderr)
+    raise SystemExit(2)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Fixes #55

## 変更内容
- `docs/style/chapter-template.md` の Markdown link 破壊（全角 `）` 混入）を修正
- Context Pack 検証の依存導線を追記
  - `docs/spec/context-pack-v1.md`
  - `index.md`（クイックスタート）
- `validate-context-pack*.py` の ImportError を捕捉し、依存導入コマンドを案内
- 再発防止: 全角 `）` 混入によるリンク破壊を検知する `scripts/check-invalid-markdown-links.py` を追加し、`npm run qa` と CI に統合

## 確認
- ローカルで `npm run qa` が完走することを確認
