### PR TITLE
Issue #57: 例題/付録Aの検証導線をminimal lint + schema validationへ統一

### DIFF
--- a/appendices/templates/index.md
+++ b/appendices/templates/index.md
@@ -9,7 +9,11 @@ appendix: templates
 
 ## Context Pack（最小スケルトン）
 
-このスケルトンは `scripts/validate-context-pack.py` の minimal lint（必須フィールド/型/ID重複/参照整合の簡易検証）を通る形です。
+このスケルトンは「着手用」の最小形です。まずは `scripts/validate-context-pack.py` の minimal lint（必須フィールド/型/ID重複/参照整合の簡易検証）で破綻を早期検知し、内容が具体化した段階で schema validation（JSON Schema による仕様準拠チェック）も通します。
+
+検証コマンドの詳細は [Context Pack v1 仕様（検証コマンド）]({{ '/docs/spec/context-pack-v1/' | relative_url }}#validation-commands) を参照してください。
+
+注意: schema validation はプレースホルダ（例: `name: <project-or-example-name>`）を具体値へ置換した段階で通す想定です。
 
 ```yaml
 version: 1

--- a/docs/examples/common-example/index.md
+++ b/docs/examples/common-example/index.md
@@ -15,11 +15,29 @@ description: "全章で参照する共通例題（Order/Payment/Inventory/Shipme
   - GitHub: [GitHub](https://github.com/itdojp/categorical-software-design-book/blob/main/docs/examples/common-example/context-pack-v1.yaml)
   - サイト内で読む: [YAML（全文）](#yaml-full)
 
-## 最小lint（ローカル）
+## 検証（ローカル）
+
+依存導入（初回のみ）:
+
+```bash
+python3 -m pip install -r scripts/requirements-qa.txt
+```
+
+minimal lint:
 
 ```bash
 python3 scripts/validate-context-pack.py docs/examples/common-example/context-pack-v1.yaml
 ```
+
+schema validation（JSON Schema）:
+
+```bash
+python3 scripts/validate-context-pack-schema.py docs/examples/common-example/context-pack-v1.yaml
+```
+
+位置づけ/差分は [Context Pack v1 仕様（検証コマンド）]({{ '/docs/spec/context-pack-v1/' | relative_url }}#validation-commands) を参照してください。
+
+（任意）CI相当の一括チェック: `npm run qa`（レポート: `qa-reports/*.json`）
 
 ## YAML（全文） {#yaml-full}
 

--- a/docs/examples/minimal-example/index.md
+++ b/docs/examples/minimal-example/index.md
@@ -15,11 +15,29 @@ description: "Context Pack v1 の最小の有効例（minimal lint）"
   - GitHub: [GitHub](https://github.com/itdojp/categorical-software-design-book/blob/main/docs/examples/minimal-example/context-pack-v1.yaml)
   - サイト内で読む: [YAML（全文）](#yaml-full)
 
-## 最小lint（ローカル）
+## 検証（ローカル）
+
+依存導入（初回のみ）:
+
+```bash
+python3 -m pip install -r scripts/requirements-qa.txt
+```
+
+minimal lint:
 
 ```bash
 python3 scripts/validate-context-pack.py docs/examples/minimal-example/context-pack-v1.yaml
 ```
+
+schema validation（JSON Schema）:
+
+```bash
+python3 scripts/validate-context-pack-schema.py docs/examples/minimal-example/context-pack-v1.yaml
+```
+
+位置づけ/差分は [Context Pack v1 仕様（検証コマンド）]({{ '/docs/spec/context-pack-v1/' | relative_url }}#validation-commands) を参照してください。
+
+（任意）CI相当の一括チェック: `npm run qa`（レポート: `qa-reports/*.json`）
 
 ## YAML（全文） {#yaml-full}
 

--- a/docs/spec/context-pack-v1.md
+++ b/docs/spec/context-pack-v1.md
@@ -20,7 +20,7 @@ Context Pack は YAML/JSON のいずれでもよいが、レビュー容易性�
 機械可読スキーマ:
 - JSON Schema: [context-pack-v1.schema.json]({{ '/docs/spec/context-pack-v1.schema.json' | relative_url }})（[raw](https://raw.githubusercontent.com/itdojp/categorical-software-design-book/main/docs/spec/context-pack-v1.schema.json)）
 
-検証コマンド:
+### 検証コマンド {#validation-commands}
 
 依存導入（初回のみ）:
 


### PR DESCRIPTION
Fixes #57

## 変更内容
- 例題ハブ（minimal/common）のローカル検証手順を「依存導入 + minimal lint + schema validation」に統一
  - `docs/examples/minimal-example/index.md`
  - `docs/examples/common-example/index.md`
- 付録A（テンプレ集）に schema validation の位置づけ/導線を追記
  - `appendices/templates/index.md`
- 参照しやすいよう、spec に検証コマンド節のアンカーを追加
  - `docs/spec/context-pack-v1.md`（`#validation-commands`）

## 確認
- ローカルで `npm run qa` が完走することを確認
