### PR TITLE
Issue #61: 演習にContext Pack検証手順を追記

### DIFF
--- a/chapters/chapter01/index.md
+++ b/chapters/chapter01/index.md
@@ -162,11 +162,17 @@ graph TD
 1. 共通例題（注文処理）の Context Pack を読む: [docs/examples/common-example/](../../docs/examples/common-example/)
 2. 次の追加要件を1つだけ定義する（例: CancelOrder を追加し、監査と状態遷移の安全性を維持）
 3. 追加要件に必要な差分を Context Pack v1 として作る（Goals/Non-goals、Objects/Morphisms/Diagrams、Acceptance tests、Forbidden changes を更新）
-4. 更新した Context Pack をAIに渡し、以下を生成させる
+4. Context Pack を更新したら検証する（編集対象に合わせてパスを置き換える）
+   - （初回のみ）`python3 -m pip install -r scripts/requirements-qa.txt`
+   - minimal lint: `python3 scripts/validate-context-pack.py <your-context-pack.yaml>`（例: `docs/examples/common-example/context-pack-v1.yaml`）
+   - schema validation: `python3 scripts/validate-context-pack-schema.py <your-context-pack.yaml>`
+   - （任意）CI相当の一括チェック: `npm run qa`
+   - 検証コマンドのSSOT: `docs/spec/context-pack-v1.md` の「検証コマンド」
+5. 更新した Context Pack をAIに渡し、以下を生成させる
    - 実装スケルトン（モジュール境界を意識）
    - 受入テスト（Acceptance tests）
    - Diagrams を壊さない検証（プロパティ/チェック観点）
-5. 人間がレビューし、Forbidden changes と Diagrams を基準に差し戻す
+6. 人間がレビューし、Forbidden changes と Diagrams を基準に差し戻す
 
 提出物（最小）:
 - 更新した Context Pack v1（YAML/JSON）

--- a/chapters/chapter04/index.md
+++ b/chapters/chapter04/index.md
@@ -142,8 +142,14 @@ AIへ引き渡す際は「保存すべき構造」を禁止事項として具体
 1. 「Morphismの追加」と「Object境界の変更」を1つずつ想定し、AIに任せる範囲を線引きする
    - 例（追加）: `CancelOrder` を追加（既存 Diagrams を維持）
    - 例（変更）: `Payment` 境界を `Order` へ統合（境界変更）
-2. それぞれについて、Context Pack の Forbidden changes と Constraints をどう書くべきか整理する
-3. AIに実装を委任する場合のレビュー観点（関手性チェックリスト）を列挙する
+2. それぞれについて、Context Pack の Forbidden changes と Constraints をどう書くべきか整理し、Context Pack を更新する
+3. Context Pack を更新したら検証する（編集対象に合わせてパスを置き換える）
+   - （初回のみ）`python3 -m pip install -r scripts/requirements-qa.txt`
+   - minimal lint: `python3 scripts/validate-context-pack.py <your-context-pack.yaml>`（例: `docs/examples/common-example/context-pack-v1.yaml`）
+   - schema validation: `python3 scripts/validate-context-pack-schema.py <your-context-pack.yaml>`
+   - （任意）CI相当の一括チェック: `npm run qa`
+   - 検証コマンドのSSOT: `docs/spec/context-pack-v1.md` の「検証コマンド」
+4. AIに実装を委任する場合のレビュー観点（関手性チェックリスト）を列挙する
 
 ## まとめ
 

--- a/chapters/chapter07/index.md
+++ b/chapters/chapter07/index.md
@@ -112,8 +112,14 @@ graph TD
 
 1. 統合ケースを1つ選ぶ（例: `Payment` を外部サービスに切り出す/統合する）
 2. 共通基準 `C`（正規形または共通インターフェース）を定義する
-3. 図式（Pullback/Pushout）の統合条件を Diagrams として記述する
-4. 図式→テスト項目（差分/互換）へ変換し、検証項目リストとして残す
+3. 図式（Pullback/Pushout）の統合条件を Context Pack の Diagrams として記述する
+4. Context Pack を更新したら検証する（編集対象に合わせてパスを置き換える）
+   - （初回のみ）`python3 -m pip install -r scripts/requirements-qa.txt`
+   - minimal lint: `python3 scripts/validate-context-pack.py <your-context-pack.yaml>`（例: `docs/examples/common-example/context-pack-v1.yaml`）
+   - schema validation: `python3 scripts/validate-context-pack-schema.py <your-context-pack.yaml>`
+   - （任意）CI相当の一括チェック: `npm run qa`
+   - 検証コマンドのSSOT: `docs/spec/context-pack-v1.md` の「検証コマンド」
+5. 図式→テスト項目（差分/互換）へ変換し、検証項目リストとして残す
 
 ## まとめ
 

--- a/chapters/chapter09/index.md
+++ b/chapters/chapter09/index.md
@@ -115,6 +115,12 @@ impure shell:
 2. failures/retry/idempotency/audit をテンプレに落とす
 3. D1（冪等）/D2（監査整合）を壊さないためのテスト観点を列挙する
 4. AIに委任する場合の禁止事項（副作用の無断追加、境界破壊）を Context Pack に追記する
+5. Context Pack を更新したら検証する（編集対象に合わせてパスを置き換える）
+   - （初回のみ）`python3 -m pip install -r scripts/requirements-qa.txt`
+   - minimal lint: `python3 scripts/validate-context-pack.py <your-context-pack.yaml>`（例: `docs/examples/common-example/context-pack-v1.yaml`）
+   - schema validation: `python3 scripts/validate-context-pack-schema.py <your-context-pack.yaml>`
+   - （任意）CI相当の一括チェック: `npm run qa`
+   - 検証コマンドのSSOT: `docs/spec/context-pack-v1.md` の「検証コマンド」
 
 ## まとめ
 


### PR DESCRIPTION
Fixes #61
Fixes #64

## 変更内容
- 第1/4/7/9章の演習に、Context Pack 更新後の検証（minimal lint + schema validation + 任意で npm run qa）を追記
- 「検証コマンドのSSOT」を spec の `#validation-commands` へリンク化
- schema validation 行にも common-example の例を追記

## 動作確認
- `npm run qa`
