### PR TITLE
Add optics lenses view guidance

### DIFF
--- a/appendices/references/index.md
+++ b/appendices/references/index.md
@@ -82,7 +82,7 @@ appendix: references
   - graded modal types、linear λ-calculus、resource reasoning の概念参照として使う。
 
 
-## 参考文献（Optics / Lenses / Categorical Cybernetics）
+## 参考文献（Optics / Lenses / Categorical Cybernetics） {#ref-optics-lenses-categorical-cybernetics}
 
 - Matthew Pickering, Jeremy Gibbons, Nicolas Wu, “Profunctor Optics: Modular Data Accessors”, <https://arxiv.org/abs/1703.10857>
   - optics を data accessor として扱い、getter / setter 風の素朴な実装を合成可能な first-class accessor へ引き上げる背景として参照する。

--- a/appendices/references/index.md
+++ b/appendices/references/index.md
@@ -82,6 +82,17 @@ appendix: references
   - graded modal types、linear λ-calculus、resource reasoning の概念参照として使う。
 
 
+## 参考文献（Optics / Lenses / Categorical Cybernetics）
+
+- Matthew Pickering, Jeremy Gibbons, Nicolas Wu, “Profunctor Optics: Modular Data Accessors”, <https://arxiv.org/abs/1703.10857>
+  - optics を data accessor として扱い、getter / setter 風の素朴な実装を合成可能な first-class accessor へ引き上げる背景として参照する。
+- Bryce Clarke, Derek Elkins, Jeremy Gibbons, Fosco Loregian, Bartosz Milewski, Emily Pillmore, Mario Román, “Profunctor Optics, a Categorical Update”, <https://arxiv.org/abs/2001.07488>
+  - bidirectional data accessor としての optics、mixed / enriched optics への一般化を確認する導線。本書では詳細証明ではなく source / view / get / put / laws の実務境界に使う。
+- Jules Hedges, Riu Rodríguez Sakamoto, “Reinforcement Learning in Categorical Cybernetics”, <https://arxiv.org/abs/2404.02688>
+  - categorical cybernetics と parametrised bidirectional process の研究導線。agent loop へ接続する際の発展的背景として扱い、強化学習の詳細解説には踏み込まない。
+- CyberCat Institute, <https://cybercat.institute/>
+  - categorical cybernetics / applied category theory の研究ネットワーク。公式 About ページでは、optimization、control、intelligence を主対象とし、optics や open games などを道具として扱うことを確認する。
+
 ## 参考文献（Open Systems / Structured Cospans）
 
 - Evan Patterson, “Structured and Decorated Cospans from the Viewpoint of Double Category Theory”, <https://arxiv.org/abs/2304.00447>
@@ -131,9 +142,9 @@ appendix: references
 | 章 | 次に読む候補 |
 | --- | --- |
 | 第2〜3章 | Mac Lane / Awodey / Riehl（基礎）、Milewski（直観） |
-| 第4〜5章 | Milewski（関手/自然変換の実装直観）、Fong & Spivak（合成的設計） |
+| 第4〜5章 | Milewski（関手/自然変換の実装直観）、Fong & Spivak（合成的設計）、Profunctor Optics（Lens / Optic と DTO / view 更新） |
 | 第6章 | Fong & Spivak（普遍性の応用）、型システム入門（合併型/直積型） |
 | 第7章 | Spivak / Fong & Spivak（統合の図式化）、CQL / Functorial Data Migration（スキーマ統合・データ移行）、Pijul / patch theory（差分意味論） |
-| 第8章 | Fong & Spivak（モノイダル圏/ストリング図式の直観）、Structured / Decorated Cospans、Catlab / GATlab / CatColab、実務の並列/合流設計資料 |
+| 第8章 | Fong & Spivak（モノイダル圏/ストリング図式の直観）、Structured / Decorated Cospans、Optics / Categorical Cybernetics、Catlab / GATlab / CatColab、実務の並列/合流設計資料 |
 | 第9章 | FP文献（モナド/効果）、OCaml effects / Koka / Granule、MCP / Agents SDK（tool call と guardrail / tracing の実行境界）、形式手法（不変条件の固定） |
 | 第10章 | GitHub Actions / GitHub Copilot features / Agent Runtime Contract / テスト戦略 / レビュー運用の実務資料（再現可能性を優先） |

--- a/chapters/chapter05/index.md
+++ b/chapters/chapter05/index.md
@@ -89,7 +89,7 @@ AIにリファクタを任せると、コードの見た目は良くなるが意
 
 自然変換は、Before と After の対応がすべての操作と整合するかを確認する枠組みです。
 一方、Lens / Optic は、source と view のあいだで「読む」だけでなく、許可された更新を source へ戻す関係を明示します。
-実務では、UI mapper の便利な比喩で終わらせず、`get` / `put` / laws / forbidden updates をレビュー対象にします。
+実務では、UI mapper の便利な比喩で終わらせず、`get` / `put` / `laws` / `forbidden_updates` をレビュー対象にします。
 
 | 観点 | 自然変換 | Lens / Optic |
 | --- | --- | --- |
@@ -130,10 +130,10 @@ views:
 
 ここで重要なのは、`put` を「何でも戻せる setter」として扱わないことです。
 `OrderSummaryDTO` の編集から `Payment.status` や `AuditEvent` を直接変更できるなら、source / view の境界が壊れています。
-レビューでは、allowed updates と forbidden updates を分け、laws を acceptance test や property-based test の観点へ落とします。
+レビューでは、`allowed_updates` と `forbidden_updates` を分け、`laws` を acceptance test や property-based test の観点へ落とします。
 
 Optic の圏論的定式化には profunctor optics などの研究導線があります。
-本書では、詳細な定式化ではなく、[参考文献（Optics / Lenses / Categorical Cybernetics）]({{ '/appendices/references/' | relative_url }}#参考文献optics--lenses--categorical-cybernetics)に一次導線を残し、設計レビューで確認できる条件へ限定します。
+本書では、詳細な定式化ではなく、[参考文献（Optics / Lenses / Categorical Cybernetics）]({{ '/appendices/references/' | relative_url }}#ref-optics-lenses-categorical-cybernetics)に一次導線を残し、設計レビューで確認できる条件へ限定します。
 
 ## AIエージェントへの引き渡し
 

--- a/chapters/chapter05/index.md
+++ b/chapters/chapter05/index.md
@@ -85,6 +85,56 @@ AIにリファクタを任せると、コードの見た目は良くなるが意
 - 監査ログ（AuditEvent）
 - 外部副作用（決済/配送など）
 
+## 第5章補論: 自然変換から Lens / Optic へ
+
+自然変換は、Before と After の対応がすべての操作と整合するかを確認する枠組みです。
+一方、Lens / Optic は、source と view のあいだで「読む」だけでなく、許可された更新を source へ戻す関係を明示します。
+実務では、UI mapper の便利な比喩で終わらせず、`get` / `put` / laws / forbidden updates をレビュー対象にします。
+
+| 観点 | 自然変換 | Lens / Optic |
+| --- | --- | --- |
+| 主な問い | Before / After の差分は意味保存か | view への更新を source へ安全に戻せるか |
+| 固定するもの | 対象ごとの成分と可換条件 | `get`、`put`、laws、禁止更新 |
+| 実務例 | リファクタ、互換レイヤ、データ移行 | DTO、read model、UI 編集、設定画面 |
+| 破綻例 | 操作前後で結果が一致しない | view から監査履歴や決済承認を直接書き換える |
+
+代表的な読み方は次の通りです。
+
+- `get`: source から view を作る。例: `Order` から `OrderSummaryDTO` を作る。
+- `put`: view で許可された変更だけを source へ戻す。
+- laws: `get` と `put` が不要な差分を生まないことを確認する規則。
+- `forbidden_updates`: view から直接変えてはいけない source 側の事実。
+
+Context Pack v2 では、次のように `views.lenses_or_optics` へ落とします。
+
+```yaml
+views:
+  lenses_or_optics:
+    - id: OrderSummaryView
+      source: Order
+      view: OrderSummaryDTO
+      get:
+        description: "Order から UI 表示用 DTO を作る"
+      put:
+        description: "UI/API から許可された配送先メモと表示名だけを Order へ戻す"
+        allowed_updates:
+          - displayName
+          - shippingMemo
+      laws:
+        - get_after_put_consistency
+        - put_after_get_no_spurious_change
+      forbidden_updates:
+        - change_payment_authorization_directly
+        - mutate_audit_history
+```
+
+ここで重要なのは、`put` を「何でも戻せる setter」として扱わないことです。
+`OrderSummaryDTO` の編集から `Payment.status` や `AuditEvent` を直接変更できるなら、source / view の境界が壊れています。
+レビューでは、allowed updates と forbidden updates を分け、laws を acceptance test や property-based test の観点へ落とします。
+
+Optic の圏論的定式化には profunctor optics などの研究導線があります。
+本書では、詳細な定式化ではなく、[参考文献（Optics / Lenses / Categorical Cybernetics）]({{ '/appendices/references/' | relative_url }}#参考文献optics--lenses--categorical-cybernetics)に一次導線を残し、設計レビューで確認できる条件へ限定します。
+
 ## AIエージェントへの引き渡し
 
 AIにリファクタを委任する場合は、自然性を満たすための安全柵を入力として与えます。

--- a/chapters/chapter08/index.md
+++ b/chapters/chapter08/index.md
@@ -146,12 +146,12 @@ open_systems:
 
 Lens / Optic は、第8章の配線図式では feedback loop を説明する補助線になります。
 `get` は source から agent が観測する view を作り、`put` は agent / UI が許可された差分だけを source へ戻します。
-agent loop へ接続する場合も、更新経路を自由な setter として扱わず、loop の戻り口に laws と forbidden updates を置きます。
+agent loop へ接続する場合も、更新経路を自由な setter として扱わず、loop の戻り口に `laws` と `forbidden_updates` を置きます。
 
 | loop の段階 | Lens / Optic で固定するもの | 検証観点 |
 | --- | --- | --- |
 | observe | `get` が作る view | 表示用 DTO が source の監査・権限条件を落としていないか |
-| decide | view 上の許可更新 | agent が forbidden updates を提案していないか |
+| decide | view 上の許可更新 | agent が `forbidden_updates` を提案していないか |
 | act / update | `put` が source へ戻す差分 | `get_after_put_consistency` と監査追跡が保たれるか |
 
 Categorical cybernetics は、optimization や control を optics などの道具で扱う発展的な研究導線です。

--- a/chapters/chapter08/index.md
+++ b/chapters/chapter08/index.md
@@ -142,6 +142,21 @@ open_systems:
 `OrderService` は支払取消を要求しますが、外部決済APIのretryや監査の詳細は `PaymentAdapter` 側の境界内に閉じ込めます。
 合成後の正しさは、「圏論的に合成したから正しい」ではなく、`no_orphan_payment_request` や `audit_event_preserved` のような検証条件で確認します。
 
+### Lens / Optic と feedback loop
+
+Lens / Optic は、第8章の配線図式では feedback loop を説明する補助線になります。
+`get` は source から agent が観測する view を作り、`put` は agent / UI が許可された差分だけを source へ戻します。
+agent loop へ接続する場合も、更新経路を自由な setter として扱わず、loop の戻り口に laws と forbidden updates を置きます。
+
+| loop の段階 | Lens / Optic で固定するもの | 検証観点 |
+| --- | --- | --- |
+| observe | `get` が作る view | 表示用 DTO が source の監査・権限条件を落としていないか |
+| decide | view 上の許可更新 | agent が forbidden updates を提案していないか |
+| act / update | `put` が source へ戻す差分 | `get_after_put_consistency` と監査追跡が保たれるか |
+
+Categorical cybernetics は、optimization や control を optics などの道具で扱う発展的な研究導線です。
+本書では強化学習や制御理論の詳細へ踏み込まず、agent loop の観測・更新境界を Context Pack の検証条件として書く用途に限定します。
+
 ## 実装カタログへの接続
 
 配線や分業を実装・研究カタログへ接続する場合は、[付録E: Applied Category Theory 実装カタログ]({{ '/appendices/implementation-catalog/' | relative_url }}) を参照します。

--- a/chapters/chapter10/index.md
+++ b/chapters/chapter10/index.md
@@ -204,6 +204,40 @@ data_contracts:
 
 この追加は、BI/分析向けの取消理由集計を本章へ持ち込むものではありません。non-goal を広げず、CancelOrder の運用に必要な read model と監査 lineage の保存条件だけを検証対象にします。
 
+### 4) DTO / view 更新を Lens として検証する
+
+CancelOrder の UI や API で `OrderSummaryDTO` を扱う場合、DTO は source である `Order` そのものではありません。
+view から戻してよい更新と、戻してはいけない更新を分けないと、表示項目の修正が決済承認や監査履歴の改変に化けます。
+Context Pack v2 では、view 更新を Lens / Optic の形で明示します。
+
+```yaml
+views:
+  lenses_or_optics:
+    - id: OrderSummaryView
+      source: Order
+      view: OrderSummaryDTO
+      get:
+        description: "Order と AuditEvent lineage から表示用 DTO を作る"
+        preserves:
+          - OrderId
+          - state
+          - auditLineage
+      put:
+        description: "UI から許可された表示メモだけを Order へ戻す"
+        allowed_updates:
+          - shippingMemo
+      laws:
+        - get_after_put_consistency
+        - put_after_get_no_spurious_change
+      forbidden_updates:
+        - change_payment_authorization_directly
+        - mutate_audit_history
+```
+
+レビューでは、`get` が表示に必要な監査 lineage を落としていないこと、`put` が `allowed_updates` 以外を source へ戻さないことを確認します。
+`get_after_put_consistency` は、許可された更新を戻したあと再度 DTO を作ったときに、利用者が入力した表示項目が失われないことを確認します。
+`put_after_get_no_spurious_change` は、source から作った DTO をそのまま戻しても、決済承認・監査履歴・状態遷移が余計に変わらないことを確認します。
+
 ## 第10章補論: Agent Runtime Contract をIssue/PR/CIで検証する
 
 `CancelOrder` を AI エージェントへ委任する場合、Context Pack の morphism だけでは不十分です。どの tool を呼んでよいか、どの検証を通すか、実行証跡をどこで確認するかを、Agent Runtime Contract として固定します。ここでの圏論語彙は「`CancelOrder` を正当化する証明」ではありません。対応づけは次のように分けます。
@@ -428,8 +462,8 @@ CI が落ちたときの修正順も、ケーススタディの一部です。
     </tr>
     <tr>
       <td>第5章</td>
-      <td>自然変換</td>
-      <td>差分レビューで「意味保存の変更か」を確認し、汎用 API 化を差し戻す</td>
+      <td>自然変換 / Lens</td>
+      <td>差分レビューで意味保存を確認し、DTO / view 更新は <code>get</code> / <code>put</code> / laws / forbidden updates で検証する</td>
     </tr>
     <tr>
       <td>第6章</td>

--- a/chapters/chapter10/index.md
+++ b/chapters/chapter10/index.md
@@ -463,7 +463,7 @@ CI が落ちたときの修正順も、ケーススタディの一部です。
     <tr>
       <td>第5章</td>
       <td>自然変換 / Lens</td>
-      <td>差分レビューで意味保存を確認し、DTO / view 更新は <code>get</code> / <code>put</code> / laws / forbidden updates で検証する</td>
+      <td>差分レビューで意味保存を確認し、DTO / view 更新は <code>get</code> / <code>put</code> / <code>laws</code> / <code>forbidden_updates</code> で検証する</td>
     </tr>
     <tr>
       <td>第6章</td>

--- a/docs/examples/common-example/context-pack-v2.yaml
+++ b/docs/examples/common-example/context-pack-v2.yaml
@@ -286,6 +286,26 @@ open_systems:
 
 views:
   lenses_or_optics:
+    - id: OrderSummaryView
+      source: Order
+      view: OrderSummaryDTO
+      get:
+        description: "Order と AuditEvent lineage から UI 表示用 DTO を作る"
+        preserves:
+          - OrderId
+          - state
+          - auditLineage
+      put:
+        description: "UI/API から許可された表示メモだけを Order へ戻す"
+        allowed_updates:
+          - displayName
+          - shippingMemo
+      laws:
+        - get_after_put_consistency
+        - put_after_get_no_spurious_change
+      forbidden_updates:
+        - change_payment_authorization_directly
+        - mutate_audit_history
     - id: OrderLifecycleView
       source: Order
       focus: state

--- a/docs/examples/common-example/context-pack-v2.yaml
+++ b/docs/examples/common-example/context-pack-v2.yaml
@@ -42,6 +42,8 @@ objects:
       - items
       - totalAmount
       - state
+      - displayName
+      - shippingMemo
   - id: Payment
     kind: entity
     fields:
@@ -181,7 +183,7 @@ data_contracts:
   schemas:
     - id: OrderSchema
       object: Order
-      fields: [orderId, items, totalAmount, state]
+      fields: [orderId, items, totalAmount, state, displayName, shippingMemo]
       source_of_truth: Order service database
     - id: AuditEventSchema
       object: AuditEvent

--- a/docs/examples/common-example/index.md
+++ b/docs/examples/common-example/index.md
@@ -24,7 +24,7 @@ permalink: /examples/common-example/
 
 - `data_contracts`: OrderSchema、AuditEventSchema、LegacyOrderDB、OrderReadModel と、監査 lineage を保った read model 移行検証。
 - `open_systems`: `OrderService` と `PaymentAdapter` を shared boundary で合成し、孤立した支払要求や監査欠落を防ぐ。
-- `views.lenses_or_optics`: `OrderSummaryView` の `get` / `put` / laws / forbidden updates を固定し、DTO / view 更新が決済承認や監査履歴を直接変えないことを確認する。
+- `views.lenses_or_optics`: `OrderSummaryView` の `get` / `put` / `laws` / `forbidden_updates` を固定し、DTO / view 更新が決済承認や監査履歴を直接変えないことを確認する。
 - `effects`: 永続化、在庫引当、監査ログ追記、監査エクスポートを operation / handler に分離。特に `ReserveInventory` は本番 handler と test handler を分ける。
 - `agent_runtime`: tool contract 形式の allowed tools / forbidden tools、input / output / tool invocation guardrails、PR・CI・review の trace evidence。
 - `resource_constraints`: CI 時間、PII、本番データ、冪等性キー、ワンタイム決済トークン。

--- a/docs/examples/common-example/index.md
+++ b/docs/examples/common-example/index.md
@@ -24,6 +24,7 @@ permalink: /examples/common-example/
 
 - `data_contracts`: OrderSchema、AuditEventSchema、LegacyOrderDB、OrderReadModel と、監査 lineage を保った read model 移行検証。
 - `open_systems`: `OrderService` と `PaymentAdapter` を shared boundary で合成し、孤立した支払要求や監査欠落を防ぐ。
+- `views.lenses_or_optics`: `OrderSummaryView` の `get` / `put` / laws / forbidden updates を固定し、DTO / view 更新が決済承認や監査履歴を直接変えないことを確認する。
 - `effects`: 永続化、在庫引当、監査ログ追記、監査エクスポートを operation / handler に分離。特に `ReserveInventory` は本番 handler と test handler を分ける。
 - `agent_runtime`: tool contract 形式の allowed tools / forbidden tools、input / output / tool invocation guardrails、PR・CI・review の trace evidence。
 - `resource_constraints`: CI 時間、PII、本番データ、冪等性キー、ワンタイム決済トークン。

--- a/docs/spec/context-pack-v2.md
+++ b/docs/spec/context-pack-v2.md
@@ -205,7 +205,7 @@ open_systems:
 
 読み取り view、射影、更新規則を明示します。
 view の追加が元データの制約や監査条件を破らないかをレビューできるようにします。
-Lens / Optic として書く場合は、単なる UI mapper ではなく、`get` / `put` / laws / forbidden updates を分けます。
+Lens / Optic として書く場合は、単なる UI mapper ではなく、`get` / `put` / `laws` / `forbidden_updates` を分けます。
 
 ```yaml
 views:

--- a/docs/spec/context-pack-v2.md
+++ b/docs/spec/context-pack-v2.md
@@ -203,7 +203,39 @@ open_systems:
 
 ### views.lenses_or_optics
 
-読み取り view、射影、更新規則を明示します。view の追加が元データの制約や監査条件を破らないかをレビューできるようにします。
+読み取り view、射影、更新規則を明示します。
+view の追加が元データの制約や監査条件を破らないかをレビューできるようにします。
+Lens / Optic として書く場合は、単なる UI mapper ではなく、`get` / `put` / laws / forbidden updates を分けます。
+
+```yaml
+views:
+  lenses_or_optics:
+    - id: OrderSummaryView
+      source: Order
+      view: OrderSummaryDTO
+      get:
+        description: "Order から UI 表示用 DTO を作る"
+        preserves:
+          - OrderId
+          - state
+          - auditLineage
+      put:
+        description: "UI/API から許可された変更だけを Order へ戻す"
+        allowed_updates:
+          - displayName
+          - shippingMemo
+      laws:
+        - get_after_put_consistency
+        - put_after_get_no_spurious_change
+      forbidden_updates:
+        - change_payment_authorization_directly
+        - mutate_audit_history
+```
+
+`get` は source から view を作る読み取り方向です。
+`put` は view で許可された差分だけを source へ戻す更新方向です。
+`laws` は往復時に余計な差分を生まないことを確認する規則、`forbidden_updates` は view から直接変えてはいけない source 側の事実です。
+これらは `acceptance_tests`、property-based test、または PR review checklist で確認します。
 
 ### effects
 


### PR DESCRIPTION
## Summary
- Add a Chapter 5 supplement connecting natural transformations to Lens / Optic review conditions.
- Extend Context Pack v2 `views.lenses_or_optics` examples with `get`, `put`, laws, and `forbidden_updates`.
- Add Chapter 8 feedback-loop / agent-loop connection, Chapter 10 DTO/view update validation, and references for optics / categorical cybernetics.

## Validation
- `python3 scripts/validate-context-pack.py docs/examples/common-example/context-pack-v2.yaml`
- `python3 scripts/validate-context-pack-schema.py docs/examples/common-example/context-pack-v2.yaml`
- `python3 scripts/check-metadata-consistency.py`
- `npm run check:navigation`
- `git diff --check`
- `npm run qa`
- Rendered marker smoke for Chapter 5, Chapter 8, Chapter 10, Context Pack v2 spec, common example, and references

Closes #121.
Refs #114.
