### PR TITLE
Fix mobile sidebar overlap

### DIFF
--- a/assets/css/mobile-responsive.css
+++ b/assets/css/mobile-responsive.css
@@ -54,7 +54,14 @@ html {
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
     z-index: 1000;
-    transform: translateX(-100%);
+    /*
+     * main.css imports this file before declaring the default desktop sidebar
+     * transform. Keep the closed drawer state important so the later desktop
+     * `transform: translateX(0)` rule cannot leave the TOC covering content
+     * on mobile and portrait tablet widths. The checked/open rule below is
+     * more specific and also important, so the menu button still opens it.
+     */
+    transform: translateX(-100%) !important;
     transition: transform 0.3s ease;
   }
 


### PR DESCRIPTION
## Summary

- Fixes the mobile/tablet portrait sidebar overlap for the published categorical software design book layout.
- Keeps the closed drawer state off-canvas at `<=1024px` even though `main.css` imports `mobile-responsive.css` before the later desktop `.book-sidebar { transform: translateX(0); }` rule.
- Preserves the checked/open rule so the standard menu button still opens the TOC drawer.

## Root cause

`main.css` imports `mobile-responsive.css` before declaring the default desktop sidebar transform. On mobile/tablet widths the main content margin is removed, but the later desktop `transform: translateX(0)` could override the mobile closed-drawer `transform: translateX(-100%)`, causing the fixed TOC sidebar to paint over the article content.

This PR makes the mobile closed-drawer transform important. The checked/open selector is already more specific and important, so the drawer still opens normally when toggled.

## Verification

- `npm run check:navigation`
- `npm run check:metadata`
- `npm run qa`
- `git diff --check`
- Local Jekyll `_site` served at `/categorical-software-design-book/`; Pages visual checker over 2 pages × 5 viewports passed:
  - `phone480`, `tablet` (768px), `tablet820`, `laptop1024`, `desktop`
  - result: `books=1 pages=10 ok=10 warn=0 fail=0`
- Direct Playwright probe over `/` and `/chapters/chapter01/` confirmed:
  - 480/768/820/1024px: closed drawer is off-canvas, no sidebar/content overlap, menu toggle is visible, and clicking the menu opens the drawer.
  - 1280px desktop: sidebar remains visible and content starts after the sidebar.

Refs itdojp/it-engineer-knowledge-architecture#168.
