### PR TITLE
chore: update GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           path: book-formatter
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -49,7 +49,7 @@ jobs:
           npm run check-textlint -- .. --with-preset --output ../qa-reports/textlint-report-with-preset.json --fail-on none
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -69,7 +69,7 @@ jobs:
         run: npm run check:navigation
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build rendered HTML (Jekyll)
         uses: actions/jekyll-build-pages@v1


### PR DESCRIPTION
## Summary

- Update the remaining repository workflow actions that still targeted the Node.js 20 JavaScript action runtime:
  - `actions/setup-node@v4` -> `actions/setup-node@v6`
  - `actions/setup-python@v5` -> `actions/setup-python@v6`
  - `actions/configure-pages@v5` -> `actions/configure-pages@v6`
- Keep workflow inputs, outputs, permissions, and the tested project Node.js version (`node-version: "20"`) unchanged.
- No book content or Context Pack specification files are changed.

## Warning / scope confirmation

Checked Actions run:

- Issue reference run: https://github.com/itdojp/categorical-software-design-book/actions/runs/27060455815
- Latest `main` Book QA run before this PR: https://github.com/itdojp/categorical-software-design-book/actions/runs/27091715306

The latest `main` Book QA annotation still reported these repository workflow actions as Node.js 20 runtime targets forced onto Node.js 24:

- `actions/configure-pages@v5`
- `actions/setup-node@v4`
- `actions/setup-python@v5`

`actions/checkout` and `actions/upload-artifact` are already `@v6` / `@v7` on current `main`, so this PR does not change them.

## Node.js 24 compatibility evidence

Official action metadata checked via each repository's `action.yml`:

- `actions/setup-node@v6`: `runs.using: 'node24'`  
  https://github.com/actions/setup-node/blob/v6/action.yml
- `actions/setup-python@v6`: `runs.using: 'node24'`  
  https://github.com/actions/setup-python/blob/v6/action.yml
- `actions/configure-pages@v6`: `runs.using: 'node24'`  
  https://github.com/actions/configure-pages/blob/v6/action.yml

## Verification

- `npm run qa` ✅
- `git diff --check` ✅
- `npm run check:navigation` ✅

Notes from local QA:

- `npm ci` inside the pinned `book-formatter` checkout reported existing dependency audit/deprecation warnings, but the QA command completed successfully.
- The preset textlint report is generated with `--fail-on none` as configured by the existing QA script.

Closes #137

## Residual Pages generated workflow warning

The separate `pages-build-deployment` dynamic workflow warning observed on `main` is tracked separately in #139 because the warning references `actions/checkout@v4` / `actions/upload-artifact@v4` from the generated Pages workflow, while the repository workflow already uses `actions/checkout@v6` / `actions/upload-artifact@v7`.
