### PR TITLE
[codex] Add managed Pages deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,7 +10,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,58 @@
+name: Deploy Pages
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: read
+    steps:
+      - name: Checkout book repo
+        uses: actions/checkout@v6
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+
+      - name: Build rendered HTML (Jekyll)
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+
+      - name: Check rendered HTML regressions
+        run: python scripts/check-rendered-html.py --site-root _site
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: ./_site
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
           destination: ./_site
 
       - name: Check rendered HTML regressions
-        run: python scripts/check-rendered-html.py --site-root _site
+        run: python3 scripts/check-rendered-html.py --site-root _site
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary
- Add a repository-managed GitHub Pages deployment workflow using current Pages actions (`configure-pages@v6`, `upload-pages-artifact@v5`, `deploy-pages@v5`) and `actions/checkout@v6`.
- Keep the Node 24 runtime opt-in explicit with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`.
- Reuse the existing Jekyll Pages build and rendered-HTML regression check before uploading the Pages artifact.

## Why
Issue #139 confirmed that repository-managed Book QA no longer has Node.js 20 deprecation annotations, but the legacy `pages-build-deployment` dynamic workflow still reports a warning for generated `actions/checkout@v4` / `actions/upload-artifact@v4`. The repository currently uses legacy branch-based Pages (`build_type=legacy`). This PR adds the managed workflow needed to switch Pages publishing to GitHub Actions after merge and retire the generated workflow path.

## Current-state evidence before this PR
- Current main commit: `de67df4d0a67896cc423bc4c52f99efa96b45156`
- Book QA run `27340936774`: success; check-run `qa` annotations = 0
- `pages-build-deployment` run `27340935594`: success; check-run `build` annotations = 1, warning references generated `actions/checkout@v4` and `actions/upload-artifact@v4`
- Pages API before this PR: `build_type=legacy`, source `main` / `/`

## Validation
- `bundle install` with workspace-scoped bundle path
- `npm run qa`
- `npm run check:navigation`
- `git diff --check`

## Post-merge verification plan
- Switch Pages publishing from legacy branch source to GitHub Actions workflow (`build_type=workflow`).
- Confirm the managed `Deploy Pages` workflow succeeds on `main`.
- Confirm the new `deploy` / `build` check-runs do not report the generated `actions/checkout@v4` / `actions/upload-artifact@v4` warning.
- Confirm public Pages smoke.

Refs: #139
Refs: itdojp/it-engineer-knowledge-architecture#170
