### PR TITLE
chore(ci): bump audited book-formatter pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-  BOOK_FORMATTER_REF: 'da2a49e7d2dcd9e1fa885e910c458130fe8d73a4'
+  BOOK_FORMATTER_REF: '69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c'
 
 jobs:
   qa:

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -5,7 +5,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REPORT_DIR="$ROOT/qa-reports"
 BOOK_FORMATTER_DIR="$ROOT/book-formatter"
 BOOK_FORMATTER_REMOTE_URL="${BOOK_FORMATTER_REMOTE_URL:-https://github.com/itdojp/book-formatter.git}"
-BOOK_FORMATTER_REF="${BOOK_FORMATTER_REF:-da2a49e7d2dcd9e1fa885e910c458130fe8d73a4}"
+BOOK_FORMATTER_REF="${BOOK_FORMATTER_REF:-69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c}"
 
 die() {
   local msg="$1"


### PR DESCRIPTION
## Summary
- update both active formatter defaults (custom CI and local `scripts/qa.sh`) from `da2a49e7d2dcd9e1fa885e910c458130fe8d73a4` to audited immutable SHA `69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c`
- keep custom QA, Context Pack checks, native/Jekyll build, and book content unchanged

## Audit basis
- parent: itdojp/it-engineer-knowledge-architecture#266
- candidate audit: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/266#issuecomment-4976511671
- old revision: npm audit moderate 7 / high 9 / total 16
- new revision: full and production-only npm audit 0; consumer CLI/checker/schema blobs are byte-identical

## Local verification
- actionlint 1.7.12 and `bash -n scripts/qa.sh`
- old/new formatter Unicode, textlint, links, layout-risk, and markdown-structure reports are semantically identical
- `npm run check:navigation`
- `npm run validate-deploy`
- `npm run qa` (includes formatter `npm ci`, Context Pack checks, Jekyll build, and rendered HTML checks)
- `npm run build`
- `git diff --check`

The root repository has no package lock, so root `npm ci` is not part of its QA contract; formatter `npm ci` completed inside `npm run qa`.

Closes #142
